### PR TITLE
Dot and percent signs are not allowed in video ids

### DIFF
--- a/lib/auto_html/filters/youtube.rb
+++ b/lib/auto_html/filters/youtube.rb
@@ -1,5 +1,5 @@
 AutoHtml.add_filter(:youtube).with(:width => 390, :height => 250, :frameborder => 0, :wmode => "window") do |text, options|
-  regex = /http:\/\/(www.)?youtube\.com\/watch\?v=([A-Za-z0-9._%-]*)(\&\S+)?|http:\/\/(www.)?youtu\.be\/([A-Za-z0-9._%-]*)?/
+  regex = /http:\/\/(www.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]*)(\&\S+)?|http:\/\/(www.)?youtu\.be\/([A-Za-z0-9_-]*)?/
   text.gsub(regex) do
     youtube_id = $2 || $5
     width = options[:width]


### PR DESCRIPTION
Dot and percent signs are not allowed in video ids

If the user has either of those immediately after a YouTube link, the following would happen:
- The percent sign caused an iframe with a "Bad Request" to be loaded.
- The dot caused the user to be redirected to youtube.com.
