### PR TITLE
Youtube filter regex update

### DIFF
--- a/lib/auto_html/filters/youtube.rb
+++ b/lib/auto_html/filters/youtube.rb
@@ -1,5 +1,5 @@
 AutoHtml.add_filter(:youtube).with(:width => 420, :height => 315, :frameborder => 0, :wmode => nil) do |text, options|
-  regex = /(https?):\/\/(www.)?(youtube\.com\/watch\?v=|youtu\.be\/)([A-Za-z0-9_-]*)(\&\S+)?(\S)*/
+  regex = /(https?):\/\/(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\S)*/
   text.gsub(regex) do
     protocol = $1
     youtube_id = $4


### PR DESCRIPTION
Hi Dejan,

I tried using your gem to embed a youtube video with a bit of a different url structure:

http://www.youtube.com/watch?feature=player_embedded&v=maLlpvxg6xI

The regular expression in the current filter expects the v parameter to be right after the /watch path. I updated the regex to account for the feature=player_embedded parameter.
