### PR TITLE
Removes version condition from redcarpet dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    auto_html (1.5.1)
-      redcarpet (~> 2.0.0)
+    auto_html (1.5.3)
+      redcarpet
       rinku (~> 1.5.0)
 
 GEM
@@ -74,7 +74,7 @@ GEM
     rake (0.9.2.2)
     rdoc (3.12)
       json (~> 1.4)
-    redcarpet (2.0.1)
+    redcarpet (2.1.1)
     rinku (1.5.1)
     sprockets (2.1.2)
       hike (~> 1.2)

--- a/auto_html.gemspec
+++ b/auto_html.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.homepage = 'http://github.com/dejan/auto_html'
 
   gem.add_dependency('rinku', '~> 1.5.0')
-  gem.add_dependency('redcarpet', '~> 2.0.0')
+  gem.add_dependency('redcarpet')
 
   # ensure the gem is built out of versioned files
   gem.files = Dir['Rakefile', '{bin,lib,man,test,spec}/**/*',


### PR DESCRIPTION
Did we need a version restriction for the redcarpet dependency anymore?
The current version seems compatible with the unit tests.

If yes: please tell me the incompatible use case, so I can implement a test for it.

Otherwise we can remove the version restriction to allways get the current version.
