### PR TITLE
Adds parameter markdown_options to redcarpet filter.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auto_html (1.5.1)
+    auto_html (1.5.3)
       redcarpet (~> 2.0.0)
       rinku (~> 1.5.0)
 

--- a/lib/auto_html/filters/redcarpet.rb
+++ b/lib/auto_html/filters/redcarpet.rb
@@ -1,5 +1,5 @@
 require 'redcarpet'
 
-AutoHtml.add_filter(:redcarpet).with(:renderer => Redcarpet::Render::HTML) do |text, options|
-  Redcarpet::Markdown.new(options[:renderer]).render(text)
+AutoHtml.add_filter(:redcarpet).with(:renderer => Redcarpet::Render::HTML, :markdown_options => {}) do |text, options|
+  Redcarpet::Markdown.new(options[:renderer], options[:markdown_options]).render(text)
 end

--- a/test/unit/filters/redcarpet_test.rb
+++ b/test/unit/filters/redcarpet_test.rb
@@ -28,4 +28,11 @@ class RedcarpetTest < Test::Unit::TestCase
     assert_equal '<p><a href="http://example.org/" target="_blank">This is a link</a></p>'+"\n", result
   end
 
+  def test_options
+    result = auto_html('http://example.org/') { redcarpet }
+    assert_equal '<p>http://example.org/</p>'+"\n", result
+    
+    result = auto_html('http://example.org/') { redcarpet(:markdown_options => { :autolink => true }) }
+    assert_equal '<p><a href="http://example.org/">http://example.org/</a></p>'+"\n", result
+  end
 end


### PR DESCRIPTION
This commit allows the developer to pass the Redcarpet::Markdown options through the new markdown_options parameter of the redcarpet filter.
