### PR TITLE
fix problems with safe strings

### DIFF
--- a/lib/auto_html/filter.rb
+++ b/lib/auto_html/filter.rb
@@ -13,9 +13,9 @@ module AutoHtml
     def apply(text, options = {})
       _options = @options && @options.merge(options)
       if _options
-        @block.call(text.to_s.dup, _options)
+        @block.call(text.to_s.to_str.dup, _options)
       else
-        @block.call(text.to_s.dup)
+        @block.call(text.to_s.to_str.dup)
       end
     end
   end


### PR DESCRIPTION
using gsub on safe strings doesn't work - $1, $2, are empty. to avoid this, use to_str, as well as to_s before passing to filters.

 using to_str alone could be a problem, since it will not convert nil to "", but fail, so use to_s.to_str