### PR TITLE
Permit auto_html_for on an attribute that's not in the DB.

### DIFF
--- a/lib/auto_html/auto_html_for.rb
+++ b/lib/auto_html/auto_html_for.rb
@@ -28,7 +28,7 @@ module AutoHtmlFor
       missing_cache_columns.each do |missing_cache_column|
         raw_attr = missing_cache_column.gsub(suffix, '')
         define_method(missing_cache_column) do
-          val = self[raw_attr]
+          val = self[raw_attr] || self.send(raw_attr.to_sym)
           auto_html(val, &proc)
         end
       end

--- a/test/functional/auto_html_for_test.rb
+++ b/test/functional/auto_html_for_test.rb
@@ -9,6 +9,11 @@ class Article < ActiveRecord::Base
     link(:target => "_blank")
     simple_format
   end
+
+  alias_attribute :plain_body, :body
+  auto_html_for :plain_body do
+    html_escape
+  end
 end
 
 class AutoHtmlForTest < Test::Unit::TestCase
@@ -42,5 +47,10 @@ class AutoHtmlForTest < Test::Unit::TestCase
     @article.update_attributes(:body => 'http://vukajlija.com')
     @article.save!
     assert_equal '<p><a href="http://vukajlija.com" target="_blank">http://vukajlija.com</a></p>', @article.body_html
+  end
+
+  def test_transform_of_alias_attribute
+    @article = Article.new(:body => 'Hello there.')
+    assert_equal 'Hello there.', @article.plain_body_html
   end
 end


### PR DESCRIPTION
This makes it possible to declare an aliased attribute in your model, then call auto_html_for with a different set of options.

This used to work in an older version (1.3.x), but I noticed it failing when I updated this gem in an app.
