### PR TITLE
Leave img tags alone in the image filter. They are already formatted.

### DIFF
--- a/lib/auto_html/filters/image.rb
+++ b/lib/auto_html/filters/image.rb
@@ -9,7 +9,7 @@ end
 AutoHtml.add_filter(:image).with({:alt => ''}) do |text, options|
   r = Redcarpet::Markdown.new(NoParagraphRenderer)
   alt = options[:alt]
-  text.gsub(/https?:\/\/.+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
+  text.gsub(/(?<!src=")https?:\/\/.+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
     r.render("![#{alt}](#{match})")
   end
 end

--- a/test/unit/filters/image_test.rb
+++ b/test/unit/filters/image_test.rb
@@ -12,6 +12,11 @@ class ImageTest < Test::Unit::TestCase
     assert_equal 'http://blog.phusion.nl/2009/04/16/phusions-one-year-anniversary-gift-phusion-passenger-220/', result
   end
 
+  def test_dont_transform_a_formatted_image
+    result = auto_html('<img src="http://farm4.static.flickr.com/3459/3270173112_5099d3d730.jpg" alt=""/>'){ image({:alt => nil}) }
+    assert_equal '<img src="http://farm4.static.flickr.com/3459/3270173112_5099d3d730.jpg" alt=""/>', result
+  end
+
   def test_transform2
     result = auto_html('http://farm4.static.flickr.com/3459/3270173112_5099d3d730.jpg') { image({:alt => nil}) }
     assert_equal '<img src="http://farm4.static.flickr.com/3459/3270173112_5099d3d730.jpg" alt=""/>', result


### PR DESCRIPTION
Adds some regex to the image filter to make sure we don't transform things that are already img tags.

Helpful when using redcarpet in front of the image filter.
