### PR TITLE
Add :proxy option to image filter

### DIFF
--- a/lib/auto_html/filters/image.rb
+++ b/lib/auto_html/filters/image.rb
@@ -3,13 +3,14 @@ require 'redcarpet'
 class NoParagraphRenderer < ::Redcarpet::Render::XHTML
   def paragraph(text)
     text
-  end    
+  end
 end
 
 AutoHtml.add_filter(:image).with({:alt => ''}) do |text, options|
   r = Redcarpet::Markdown.new(NoParagraphRenderer)
   alt = options[:alt]
+  options[:proxy] ||= ""
   text.gsub(/https?:\/\/.+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
-    r.render("![#{alt}](#{match})")
+    r.render("![#{alt}](#{options[:proxy]}#{match})")
   end
 end

--- a/test/unit/filters/image_test.rb
+++ b/test/unit/filters/image_test.rb
@@ -52,4 +52,9 @@ class ImageTest < Test::Unit::TestCase
     assert_equal '<img src="https://img.skitch.com/20100910-1wrbg5749xe29ya5t3s85bnaiy.png" alt=""/>', result
   end
 
+  def test_proxy_option
+    result = auto_html('http://img.skitch.com/20100910-1wrbg5749xe29ya5t3s85bnaiy.png') { image({:alt => nil,:proxy => "https://proxy/?url="}) }
+    assert_equal '<img src="https://proxy/?url=http://img.skitch.com/20100910-1wrbg5749xe29ya5t3s85bnaiy.png" alt=""/>', result
+  end
+
 end


### PR DESCRIPTION
I have a site that is served over https. Auto_html works great, but I get a nasty [mixed content warning](http://37signals.com/svn/posts/1431-mixed-content-warning-how-i-loathe-thee) when someone pastes a cat picture from tumblr without using https://

The added :proxy option to the image filter allows the resulting image url to pass through a proxy probably just serves up the image over the SSL connection and the browser bar stays green.
