### PR TITLE
filters/gist, support new gist url

### DIFF
--- a/lib/auto_html/filters/gist.rb
+++ b/lib/auto_html/filters/gist.rb
@@ -1,9 +1,10 @@
 AutoHtml.add_filter(:gist).with({}) do |text, options|
-  # E.g. https://gist.github.com/1710276
-  regex = /https:\/\/gist\.github\.com\/(\d+)/
+  # E.g. https://gist.github.com/account_name/hash_id
+  regex = /https:\/\/gist\.github\.com\/(\w+)\/(\w+)/
   text.gsub(regex) do
-    gist_id = $1
-    %{<script src="https://gist.github.com/#{gist_id}.js"></script>}
+    gist_account = $1
+    gist_id = $2
+    %{<script src="https://gist.github.com/#{gist_account}/#{gist_id}.js"></script>}
   end
 end
 

--- a/test/unit/filters/gist_test.rb
+++ b/test/unit/filters/gist_test.rb
@@ -3,8 +3,8 @@ require File.expand_path('../../unit_test_helper', __FILE__)
 class GistTest < Test::Unit::TestCase
 
   def test_transform
-    result = auto_html('https://gist.github.com/1710276') { gist }
-    assert_equal '<script src="https://gist.github.com/1710276.js"></script>', result
+    result = auto_html('https://gist.github.com/joaomilho/1710276') { gist }
+    assert_equal '<script src="https://gist.github.com/joaomilho/1710276.js"></script>', result
   end
 
 end


### PR DESCRIPTION
Since gist url changes its rule, filter/gist can't work anymore.
This pr supports any gist which is public or secret.
