### PR TITLE
Remove gem.date from gemspec

### DIFF
--- a/auto_html.gemspec
+++ b/auto_html.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name = 'auto_html'
   gem.version = '1.6.0'
-  gem.date = Date.today.to_s
 
   gem.summary = "Transform URIs to appropriate markup"
   gem.description = "Automatically transforms URIs (via domain) and includes the destination resource (Vimeo, YouTube movie, image, ...) in your document"


### PR DESCRIPTION
This was causing errors when deploying to engine yard and heroku.

I've seen many other repos have the same issue. Another solution would be to add require
'date' to the gemspec, but I find setting gem.date to today's date somewhat useless.
