### PR TITLE
Exclude spaces from link matching for Soundcloud filter

### DIFF
--- a/lib/auto_html/filters/soundcloud.rb
+++ b/lib/auto_html/filters/soundcloud.rb
@@ -4,7 +4,7 @@ require 'net/http'
 AutoHtml.add_filter(:soundcloud).with({}) do |text, options|
   # set these options
   # :maxwidth => '', :maxheight => '', :auto_play => false, :show_comments => false
-  text.gsub(/(https?:\/\/)?(www.)?soundcloud\.com\/.*/) do |match|
+  text.gsub(/(https?:\/\/)?(www.)?soundcloud\.com\/\S*/) do |match|
     new_uri = match.to_s
     new_uri = (new_uri =~ /^https?\:\/\/.*/) ? URI(new_uri) : URI("http://#{new_uri}")
     new_uri.normalize!


### PR DESCRIPTION
Otherwise it matches all the text after the link.
