### PR TITLE
Update the gist filter to handle username

### DIFF
--- a/lib/auto_html/filters/gist.rb
+++ b/lib/auto_html/filters/gist.rb
@@ -1,9 +1,8 @@
 AutoHtml.add_filter(:gist).with({}) do |text, options|
   # E.g. https://gist.github.com/1710276
-  regex = /https:\/\/gist\.github\.com\/(\d+)/
+  regex = %r{https?://gist\.github\.com/(\w+/)?(\d+)}
   text.gsub(regex) do
-    gist_id = $1
+    gist_id = $2
     %{<script src="https://gist.github.com/#{gist_id}.js"></script>}
   end
 end
-

--- a/test/unit/filters/gist_test.rb
+++ b/test/unit/filters/gist_test.rb
@@ -7,4 +7,9 @@ class GistTest < Test::Unit::TestCase
     assert_equal '<script src="https://gist.github.com/1710276.js"></script>', result
   end
 
+  def test_transform_with_username
+    result = auto_html('https://gist.github.com/toctan/6547840') { gist }
+    assert_equal '<script src="https://gist.github.com/6547840.js"></script>', result
+  end
+
 end


### PR DESCRIPTION
The old gist filter doesn't work on gist url with username, e.g. https://gist.github.com/toctan/6547840

By the way, I'm working on a project that will add several filters for services in China, like Youku, Tudou...
Would you like me to sent a PR to merge these filters?
