### PR TITLE
Feature/cleaner link display

### DIFF
--- a/lib/auto_html/filters/soundcloud.rb
+++ b/lib/auto_html/filters/soundcloud.rb
@@ -1,19 +1,23 @@
-# encoding: UTF-8
+require 'uri'
+require 'net/http'
 
-# set these options and default values
-# :width => '100%', :height => 166, :auto_play => false, :theme_color => '00FF00', :color => '915f33', :show_comments => false
-AutoHtml.add_filter(:soundcloud).with(:width => '100%', :height => 166, :auto_play => false, :theme_color => '00FF00', :color => '915f33', :show_comments => false, :show_artwork => false) do |text, options|
+AutoHtml.add_filter(:soundcloud).with({}) do |text, options|
+  # set these options
+  # :maxwidth => '', :maxheight => '', :auto_play => false, :show_comments => false
   text.gsub(/(https?:\/\/)?(www.)?soundcloud\.com\/.*/) do |match|
     new_uri = match.to_s
     new_uri = (new_uri =~ /^https?\:\/\/.*/) ? URI(new_uri) : URI("http://#{new_uri}")
     new_uri.normalize!
-    width = options[:width]
-    height = options[:height]
-    auto_play = options[:auto_play]
-    theme_color = options[:theme_color]
-    color = options[:color]
-    show_artwork = options[:show_artwork]
-    show_comments = options[:show_comments]
-    %{<iframe width="#{width}" height="#{height}" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=#{new_uri}&show_artwork=#{show_artwork}&show_comments=#{show_comments}&auto_play=#{auto_play}&color=#{color}&theme_color=#{theme_color}"></iframe>}
+
+    uri = URI("http://soundcloud.com/oembed")
+    params = {:format => 'json', :url => new_uri}.merge(options)
+    uri.query = params.collect { |k,v| "#{k}=#{CGI::escape(v.to_s)}" }.join('&')
+    response = Net::HTTP.get(uri)
+    if !response.blank?
+      JSON.parse(response)["html"]
+    else
+      match
+    end
   end
 end
+

--- a/test/unit/filters/soundcloud_test.rb
+++ b/test/unit/filters/soundcloud_test.rb
@@ -2,28 +2,37 @@ require File.expand_path('../../unit_test_helper', __FILE__)
 require 'fakeweb'
 
 class SoundcloudTest < Test::Unit::TestCase
+  
+  def setup
+    response = '{"version":1.0,"type":"rich","provider_name":"SoundCloud","provider_url":"http://soundcloud.com","height":166,"width":"100%","title":"Flickermood by Forss","description":"From the Soulhack album,\u0026nbsp;recently featured in this ad \u003Ca href=\"https://www.dswshoes.com/tv_commercial.jsp?m=october2007\"\u003Ehttps://www.dswshoes.com/tv_commercial.jsp?m=october2007\u003C/a\u003E ","thumbnail_url":"http://i1.sndcdn.com/artworks-000000001720-91c40a-t500x500.jpg?330b92d","html":"\u003Ciframe width=\"100%\" height=\"166\" scrolling=\"no\" frameborder=\"no\" src=\"http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F293\u0026show_artwork=true\"\u003E\u003C/iframe\u003E","author_name":"Forss","author_url":"http://soundcloud.com/forss"}'
+    FakeWeb.register_uri(:get, %r|http://soundcloud\.com/oembed|, :body => response)
+  end
+  
   def test_transform_url_with_www
     result = auto_html('http://www.soundcloud.com/forss/flickermood') { soundcloud }
-    assert_equal '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http://www.soundcloud.com/forss/flickermood&show_artwork=false&show_comments=false&auto_play=false&color=915f33&theme_color=00FF00"></iframe>', result
+    assert_equal '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F293&show_artwork=true"></iframe>', result
   end
 
   def test_transform_url_without_www
     result = auto_html('http://soundcloud.com/forss/flickermood') { soundcloud }
-    assert_equal '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http://soundcloud.com/forss/flickermood&show_artwork=false&show_comments=false&auto_play=false&color=915f33&theme_color=00FF00"></iframe>', result
+    assert_equal '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F293&show_artwork=true"></iframe>', result
   end
 
   def test_transform_url_without_protocol
     result = auto_html('soundcloud.com/forss/flickermood') { soundcloud }
-    assert_equal '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http://soundcloud.com/forss/flickermood&show_artwork=false&show_comments=false&auto_play=false&color=915f33&theme_color=00FF00"></iframe>', result
+    assert_equal '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F293&show_artwork=true"></iframe>', result
   end
 
   def test_transform_url_with_ssl
     result = auto_html('https://soundcloud.com/forss/flickermood') { soundcloud }
-    assert_equal '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=https://soundcloud.com/forss/flickermood&show_artwork=false&show_comments=false&auto_play=false&color=915f33&theme_color=00FF00"></iframe>', result
+    assert_equal '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F293&show_artwork=true"></iframe>', result
   end
 
   def test_transform_url_with_options
-    result = auto_html('http://www.soundcloud.com/forss/flickermood') { soundcloud(:width => '50%', :height => '100', :auto_play => true, :show_comments => true) }
-    assert_equal '<iframe width="50%" height="100" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http://www.soundcloud.com/forss/flickermood&show_artwork=false&show_comments=true&auto_play=true&color=915f33&theme_color=00FF00"></iframe>', result
+    response = '{"version":1.0,"type":"rich","provider_name":"SoundCloud","provider_url":"http://soundcloud.com","height":100,"width":100,"title":"Flickermood by Forss","description":"From the Soulhack album,\u0026nbsp;recently featured in this ad \u003Ca href=\"https://www.dswshoes.com/tv_commercial.jsp?m=october2007\"\u003Ehttps://www.dswshoes.com/tv_commercial.jsp?m=october2007\u003C/a\u003E ","thumbnail_url":"http://i1.sndcdn.com/artworks-000000001720-91c40a-t500x500.jpg?330b92d","html":"\u003Ciframe width=\"100\" height=\"100\" scrolling=\"no\" frameborder=\"no\" src=\"http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F293\u0026show_artwork=true\u0026show_comments=false\u0026maxwidth=100\u0026maxheight=100\u0026auto_play=false\"\u003E\u003C/iframe\u003E","author_name":"Forss","author_url":"http://soundcloud.com/forss"}'
+    FakeWeb.register_uri(:get, %r|http://soundcloud\.com/oembed|, :body => response)
+
+    result = auto_html('http://www.soundcloud.com/forss/flickermood') { soundcloud(:maxwidth => '100', :maxheight => '100', :auto_play => false, :show_comments => false) }
+    assert_equal '<iframe width="100" height="100" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F293&show_artwork=true&show_comments=false&maxwidth=100&maxheight=100&auto_play=false"></iframe>', result
   end
 end


### PR DESCRIPTION
This Pull Request adds the options to links to shorten to link name. It removes the get parameters from the url in the link name tag but keeps them for the url. This produces shorter url and hide complex parameters.
