### PR TITLE
Fix Twitter and test

### DIFF
--- a/lib/auto_html/filters/twitter.rb
+++ b/lib/auto_html/filters/twitter.rb
@@ -2,7 +2,7 @@ AutoHtml.add_filter(:twitter).with({}) do |text, options|
   require 'uri'
   require 'net/http'
 
-  regex = %r{(?<!href=")https://twitter\.com(/#!)?/[A-Za-z0-9_]{1,15}/status(es)?/\d+}
+  regex = %r{(?<!href=")https://twitter\.com(/#!)?/[A-Za-z0-9_]{1,15}/status(es)?/\d+(/?)}
 
   text.gsub(regex) do |match|
     params = { :url => match }.merge(options)

--- a/test/unit/filters/twitter_test.rb
+++ b/test/unit/filters/twitter_test.rb
@@ -28,6 +28,12 @@ class TwitterTest < Test::Unit::TestCase
     assert_equal transformed_html, result
   end
 
+  def test_transform_with_dangling_slash
+    transformed_html = "things"
+    result = auto_html('https://twitter.com/danmartell/statuses/279651488517738496/') { twitter }
+    assert_equal transformed_html, result
+  end
+
   def test_dont_transform_a_regular_link_to_twitter
     transformed_html = %Q(<blockquote class="twitter-tweet"><p>Stop saying you can&#39;t! Start asking &quot;What would need to be true for me to accomplish this&quot; - it&#39;ll change your life. <a href="https://twitter.com/search?q=%23focus&amp;src=hash">#focus</a> <a href="https://twitter.com/search?q=%23solutions&amp;src=hash">#solutions</a></p>&mdash; Dan Martell (@danmartell) <a href="https://twitter.com/danmartell/statuses/279651488517738496">December 14, 2012</a></blockquote>
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>)


### PR DESCRIPTION
Twitter requires SSL for the oembed request. Update test with a current response and match on the actual HTML.
