### PR TITLE
Some URLs can cause "bad URI error" when using the URI lib.

### DIFF
--- a/lib/auto_html/filters/soundcloud.rb
+++ b/lib/auto_html/filters/soundcloud.rb
@@ -3,12 +3,10 @@
 # set these options and default values
 # :width => '100%', :height => 166, :auto_play => false, :theme_color => '00FF00', :color => '915f33', :show_comments => false
 AutoHtml.add_filter(:soundcloud).with(:width => '100%', :height => 166, :auto_play => false, :theme_color => '00FF00', :color => '915f33', :show_comments => false, :show_artwork => false) do |text, options|
-  require 'uri'
-  require 'net/http'
   text.gsub(/(https?:\/\/)?(www.)?soundcloud\.com\/\S*/) do |match|
     new_uri = match.to_s
-    new_uri = (new_uri =~ /^https?\:\/\/.*/) ? URI(new_uri) : URI("http://#{new_uri}")
-    new_uri.normalize!
+    new_uri = (new_uri =~ /^https?\:\/\/.*/) ? new_uri : "http://#{new_uri}"
+    new_uri.strip!
     width = options[:width]
     height = options[:height]
     auto_play = options[:auto_play]

--- a/test/unit/filters/soundcloud_test.rb
+++ b/test/unit/filters/soundcloud_test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.expand_path('../../unit_test_helper', __FILE__)
 require 'fakeweb'
 
@@ -26,4 +28,24 @@ class SoundcloudTest < Test::Unit::TestCase
     result = auto_html('http://www.soundcloud.com/forss/flickermood') { soundcloud(:width => '50%', :height => '100', :auto_play => true, :show_comments => true) }    
     assert_equal '<iframe width="50%" height="100" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http://www.soundcloud.com/forss/flickermood&show_artwork=false&show_comments=true&auto_play=true&color=915f33&theme_color=00FF00"></iframe>', result
   end
+
+
+  def test_can_handle_urls_in_html_1
+    txt = %Q{ 
+      http://blog.nu-soulmag.com/wp-content/uploads/2014/02/013-520x245.jpg\n<p>WATCH: Wedding Bells - http://youtu.be/HM04bKL4oq4</p>\n<p>Director - <strong>Peter Marsden</strong> \nProducer - <strong>Christina Kernohan</strong> \nStylist - <strong>Eclair Fifi</strong> \nFull Credits Within Film</p>\n<p>LISTEN: "Wedding Bells" (Zane Lowe BBC Radio 1 debut) - https://soundcloud.com/cashmerecat/wedding_bells</p>\n<p><strong>LuckyMe</strong> are proud to present: Wedding Bells; Cashmere Cat's attempt at a perfect thing in an imperfect world.</p>\n<p>soundcloud.com/cashmerecat https://twitter.com/CASHMERECAT https://www.facebook.com/cashmerecatofficial‎</p>
+    }
+    assert_nothing_raised do
+      result = auto_html(txt) { soundcloud }
+    end
+  end
+
+  def test_can_handle_urls_in_html_2
+    txt = %Q{
+    http://www.deepbeep.com.br/wp-content/uploads/2014/02/duck-sauce.jpg\n<p>A-Track e Van Helden: big as the world</p>\n<p>Já se vão quase 3 anos de “Barbra Streisand”, o hit-meme da dupla <strong>Duck Sauce</strong> aka Van Helden & A-Trak. E a boa notícia é que a discografia desses patos talentosos da música eletrônica bem-humorada segue abastecida, agora com um momento mais glamouroso e maduro, o EP “Duck Droppings”, que saiu agora em 2014.<span></span></p>\n<p>De download gratuito, para abastecer sem milongas o case alheio, esses <em>droppings</em> novos da dupla americana já haviam aparecido em seus sets e são um bom trabalho de transformar samples loopados de disco e música negra em house music acelerada (128 BPM), com um ar <em>french touch</em> saudoso que lembra rádios FMs do fim dos anos 90.</p>\n<p>Falando em FM, “Louie The First” sampleia a clássica “Brother Louie”, do Hot Chocolate, clássico de rádios animadas mundo afora. “Mondo” é nosso destaque do EP, com sua guitarra suingada correndo junto do beat e mais sample disco. </p>\n<p>Em outras notícias, A-Trak também sacou beats para o rapper veterano Cam’ron. É o EP “Federal Reserve”, ainda sem audição completa, mas com uma maravilhosa artwork de grafite que lembra o estilo paulistano e faixa boa onda “Humprey” – ouça aqui.</p>\n<p> </p>\n<p>soundcloud.com/ducksaucenyc  quackisback.com</p>
+    }
+    assert_nothing_raised do
+      result = auto_html(txt) { soundcloud }
+    end
+  end
+
 end


### PR DESCRIPTION
It's not necessary to use the URI lib for this filter implementation so
best to remove it.