### PR TITLE
Bug/ensure markdown image code not transformed

### DIFF
--- a/.autotest
+++ b/.autotest
@@ -1,0 +1,27 @@
+require 'autotest/growl'
+require 'autotest/fsevent'
+require 'redgreen'
+
+Autotest.add_hook :initialize do |at|
+  unless ARGV.empty?
+    at.find_directories = ARGV
+  else
+    # Clear all mappings
+    #at.clear_mappings
+
+    # Ignore these files
+    %w(
+      .hg .git .svn stories tmtags 
+      Gemfile Rakefile Capfile README 
+      .html app/assets config .keep
+      spec/spec.opts spec/rcov.opts vendor/gems vendor/ruby 
+      autotest svn-commit .DS_Store
+    ).each { |exception|at.add_exception(exception) }
+
+    # Now add support for the test files themselves
+    at.add_mapping(%r%^test/(.*)/(.*)\.rb$%) do |file, m|
+      at.files_matching %r%#{file}%
+    end
+
+  end
+end

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ test.sqlite3
 TODO
 Gemfile.lock
 *.gem
+.bundle
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,9 @@ end
 gem "rails", rails 
 gem 'sqlite3', '~> 1.3.3'
 gem 'fakeweb'
+
+# For testing
+gem 'autotest'
+gem 'autotest-growl'
+gem 'autotest-fsevent'
+gem 'mynyml-redgreen'

--- a/lib/auto_html/filters/image.rb
+++ b/lib/auto_html/filters/image.rb
@@ -10,7 +10,7 @@ AutoHtml.add_filter(:image).with({:alt => ''}) do |text, options|
   r = Redcarpet::Markdown.new(NoParagraphRenderer)
   alt = options[:alt]
   options[:proxy] ||= ""
-  text.gsub(/(?<!src=")https?:\/\/.+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
+  text.gsub(/(?<=^|\s)https?:\/\/.+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
     r.render("![#{alt}](#{options[:proxy]}#{match})")
   end
 end

--- a/test/unit/filters/image_test.rb
+++ b/test/unit/filters/image_test.rb
@@ -52,6 +52,18 @@ class ImageTest < Test::Unit::TestCase
     assert_equal 'Which do you prefer, this one <img src="http://www.lockhartfineart.com/images/Rio_Grande_Frost.JPG" alt=""/>, or this one <img src="http://rors.org/images/rails.png" alt=""/>?', result
   end
 
+  def test_markdown_not_transformed
+    img_markdown = "![GOOG logo](http://www.google.com/images/srpr/logo11w.png)"
+    result = auto_html(img_markdown) { image }
+    assert_equal img_markdown, result
+  end
+
+  def test_image_tag_not_transformed
+    result = auto_html('<img src="http://img.skitch.com/20100910-1wrbg5749xe29ya5t3s85bnaiy.png" />') { image }
+    assert_equal '<img src="http://img.skitch.com/20100910-1wrbg5749xe29ya5t3s85bnaiy.png" />', result
+  end
+
+
   def test_https
     result = auto_html('https://img.skitch.com/20100910-1wrbg5749xe29ya5t3s85bnaiy.png') { image({:alt => nil}) }
     assert_equal '<img src="https://img.skitch.com/20100910-1wrbg5749xe29ya5t3s85bnaiy.png" alt=""/>', result


### PR DESCRIPTION
Image links inside markdown code get transformed when they shouldn't be.