### PR TITLE
Prevent links inside already pasted HTML from being transformed again

### DIFF
--- a/lib/auto_html/filters/dailymotion.rb
+++ b/lib/auto_html/filters/dailymotion.rb
@@ -1,5 +1,5 @@
 AutoHtml.add_filter(:dailymotion).with(:width => 480, :height => 360) do |text, options|
-  text.gsub(/http:\/\/www\.dailymotion\.com.*\/video\/(.+)_*/) do
+  text.gsub(/(?<!=")https?:\/\/www\.dailymotion\.com.*\/video\/(.+)_*/) do
     video_id = $1
     %{<object type="application/x-shockwave-flash" data="http://www.dailymotion.com/swf/#{video_id}&related=0" width="#{options[:width]}" height="#{options[:height]}"><param name="movie" value="http://www.dailymotion.com/swf/#{video_id}&related=0"></param><param name="allowFullScreen" value="true"></param><param name="allowScriptAccess" value="always"></param><a href="http://www.dailymotion.com/video/#{video_id}?embed=1"><img src="http://www.dailymotion.com/thumbnail/video/#{video_id}" width="#{options[:width]}" height="#{options[:height]}"/></a></object>}
   end

--- a/test/unit/filters/dailymotion_test.rb
+++ b/test/unit/filters/dailymotion_test.rb
@@ -17,4 +17,16 @@ class DailyMotionTest < Test::Unit::TestCase
     assert_equal '<object type="application/x-shockwave-flash" data="http://www.dailymotion.com/swf/xakv5i&related=0" width="500" height="300"><param name="movie" value="http://www.dailymotion.com/swf/xakv5i&related=0"></param><param name="allowFullScreen" value="true"></param><param name="allowScriptAccess" value="always"></param><a href="http://www.dailymotion.com/video/xakv5i?embed=1"><img src="http://www.dailymotion.com/thumbnail/video/xakv5i" width="500" height="300"/></a></object>', result
   end
 
+
+  def test_prevent_html_transform
+    str = '<object type="application/x-shockwave-flash" data="http://www.dailymotion.com/swf/xakv5i&related=0" width="500" height="300"><param name="movie" value="http://www.dailymotion.com/swf/xakv5i&related=0"></param><param name="allowFullScreen" value="true"></param><param name="allowScriptAccess" value="always"></param><a href="http://www.dailymotion.com/video/xakv5i?embed=1"><img src="http://www.dailymotion.com/thumbnail/video/xakv5i" width="500" height="300"/></a></object>'
+
+    result = auto_html(str) { dailymotion(:width => 500, :height => 300) }
+
+    assert_equal(
+      str, result, 
+      "Should not re-transform HTML with dailymotion links inside of it"
+    )
+  end
+
 end

--- a/test/unit/filters/vimeo_test.rb
+++ b/test/unit/filters/vimeo_test.rb
@@ -47,4 +47,16 @@ class VimeoTest < Test::Unit::TestCase
     assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
   end
 
+  def test_prevent_html_transform
+    str = '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>'
+
+    result = auto_html(str) { vimeo }
+
+    assert_equal(
+      str, result, 
+      "Should not re-transform HTML with Vimeo links inside of it"
+    )
+  end
+
+
 end

--- a/test/unit/filters/worldstar_test.rb
+++ b/test/unit/filters/worldstar_test.rb
@@ -11,4 +11,15 @@ class WorldstarTest < Test::Unit::TestCase
 		result = auto_html('http://www.worldstarhiphop.com/videos/video.php?v=wshhc29WLkx550Hv9o31') { worldstar(:width => 400, :height => 250)}
 		assert_equal '<object width="400" height="250"><param name="movie" value="http://www.worldstarhiphop.com/videos/e/16711680/wshhc29WLkx550Hv9o31"><param name="allowFullScreen" value="true"></param><embed src="http://www.worldstarhiphop.com/videos/e/16711680/wshhc29WLkx550Hv9o31" type="application/x-shockwave-flash" allowFullscreen="true" width="400" height="250"></embed></object>', result
 	end
+
+  def test_prevent_html_transform
+    str = '<object width="400" height="250"><param name="movie" value="http://www.worldstarhiphop.com/videos/e/16711680/wshhc29WLkx550Hv9o31"><param name="allowFullScreen" value="true"></param><embed src="http://www.worldstarhiphop.com/videos/e/16711680/wshhc29WLkx550Hv9o31" type="application/x-shockwave-flash" allowFullscreen="true" width="400" height="250"></embed></object>'
+
+    result = auto_html(str) { vimeo }
+
+    assert_equal(
+      str, result, 
+      "Should not re-transform HTML with WorldStar links inside of it"
+    )
+  end
 end

--- a/test/unit/filters/youtube_test.rb
+++ b/test/unit/filters/youtube_test.rb
@@ -56,4 +56,16 @@ class YouTubeTest < Test::Unit::TestCase
     result = auto_html("www.youtube.com/watch?v=t7NdBIA4zJg") { youtube }
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>', result
   end
+
+  def test_prevent_html_transform
+    str = '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>'
+
+    result = auto_html(str) { youtube }
+
+    assert_equal(
+      str, result, 
+      "Should not re-transform HTML with YouTube links inside of it"
+    )
+  end
+
 end


### PR DESCRIPTION
If HTML already exists with dailymotion code, the existing regex clobbers it and uglifies everything.