### PR TITLE
Support start/end time params for Youtube URLs

### DIFF
--- a/lib/auto_html/filters/youtube.rb
+++ b/lib/auto_html/filters/youtube.rb
@@ -6,9 +6,17 @@ AutoHtml.add_filter(:youtube).with(:width => 420, :height => 315, :frameborder =
       params['start'].gsub(/\D/,'')
     elsif params['t']
       # convert timecode to seconds
-      matched_time = params['t'].match(/((\d+)m)?(\d+)s/)
-      min,sec = matched_time[2..3].map(&:to_i)
-      min * 60 + sec
+      seconds = params['t'].scan(/(\d+)(.)/).map do |time, unit|
+        case unit
+        when 'h'
+          time.to_i * 3600
+        when 'm'
+          time.to_i * 60
+        else
+          time.to_i
+        end
+      end
+      seconds.sum
     end
   }
 

--- a/lib/auto_html/filters/youtube.rb
+++ b/lib/auto_html/filters/youtube.rb
@@ -28,10 +28,10 @@ AutoHtml.add_filter(:youtube).with(:width => 420, :height => 315, :frameborder =
 
     if options[:user_params] && $5
       user_params = Hash[$5.split(/[\?\&]/).reject(&:blank?).map{|s| s.split('=')}]
-      start_time = start_time.call(user_params)
-      end_time = user_params['end']
-      params << "start=#{start_time}" if start_time
-      params << "end=#{end_time.gsub(/\D/,'')}" if end_time
+      start_time_param = start_time.call(user_params)
+      end_time_param = user_params['end']
+      params << "start=#{start_time_param}" if start_time_param
+      params << "end=#{end_time_param.gsub(/\D/,'')}" if end_time_param
     end
 
     src += "?#{params.join '&'}" unless params.empty?

--- a/test/unit/filters/youtube_image_test.rb
+++ b/test/unit/filters/youtube_image_test.rb
@@ -17,12 +17,12 @@ class YouTubeImageTest < Test::Unit::TestCase
     assert_equal '<div class="thumbnail youtube"><a href="https://www.youtube.com/watch?v=BwNrmYRiX_o" target="_blank"><img src="//img.youtube.com/vi/BwNrmYRiX_o/mqdefault.jpg" width="320" height="315" border="0"></a></div>', result
   end
 
-  def test_transform3
+  def test_transform4
     result = auto_html('foo http://www.youtube.com/watch?v=fT1ahr81HLw bar') { youtube_image }
     assert_equal 'foo <div class="thumbnail youtube"><a href="https://www.youtube.com/watch?v=fT1ahr81HLw" target="_blank"><img src="//img.youtube.com/vi/fT1ahr81HLw/mqdefault.jpg" width="320" height="315" border="0"></a></div> bar', result
   end
 
-  def test_transform4
+  def test_transform5
     result = auto_html('foo http://www.youtube.com/watch?v=fT1ahr81HLw<br>bar') { youtube_image }
     assert_equal 'foo <div class="thumbnail youtube"><a href="https://www.youtube.com/watch?v=fT1ahr81HLw" target="_blank"><img src="//img.youtube.com/vi/fT1ahr81HLw/mqdefault.jpg" width="320" height="315" border="0"></a></div><br>bar', result
   end

--- a/test/unit/filters/youtube_test.rb
+++ b/test/unit/filters/youtube_test.rb
@@ -68,8 +68,8 @@ class YouTubeTest < Test::Unit::TestCase
   end
 
   def test_short_with_start_timecode
-    result = auto_html("http://youtu.be/t7NdBIA4zJg?t=1m30s&hd=1") { youtube(user_params: true) }
-    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg?start=90" frameborder="0" allowfullscreen></iframe></div>', result
+    result = auto_html("http://youtu.be/t7NdBIA4zJg?t=1h10m30s&hd=1") { youtube(user_params: true) }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg?start=4230" frameborder="0" allowfullscreen></iframe></div>', result
   end
 
   def test_transform_without_protocol
@@ -80,5 +80,15 @@ class YouTubeTest < Test::Unit::TestCase
   def test_multiple_questionable_urls_in_one_string
     result = auto_html("http://www.youtube.com/watch?v=bjN8_S4xVc4&amp;feature=share&amp;list=TL5YfrkNQnNVE http://www.youtube.com/watch?v=79maSdfxQCU&amp;list=TL3GbaFhZ6ji4") { youtube(user_params: true) }
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/bjN8_S4xVc4" frameborder="0" allowfullscreen></iframe></div> <div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/79maSdfxQCU" frameborder="0" allowfullscreen></iframe></div>', result
+  end
+
+  def test_short_with_start_timecode_in_minutes_only
+    result = auto_html("http://youtu.be/qglAm8QiX5k?t=10m") { youtube(user_params: true) }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/qglAm8QiX5k?start=600" frameborder="0" allowfullscreen></iframe></div>', result
+  end
+
+  def test_short_with_start_timecode_in_seconds_only
+    result = auto_html("http://youtu.be/qglAm8QiX5k?t=33s") { youtube(user_params: true) }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/qglAm8QiX5k?start=33" frameborder="0" allowfullscreen></iframe></div>', result
   end
 end

--- a/test/unit/filters/youtube_test.rb
+++ b/test/unit/filters/youtube_test.rb
@@ -42,6 +42,16 @@ class YouTubeTest < Test::Unit::TestCase
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/BwNrmYRiX_o" frameborder="0" allowfullscreen></iframe></div>', result
   end
 
+  def test_transform_with_user_params_and_no_start_timecode
+    result = auto_html("https://www.youtube.com/watch?v=t7NdBIA4zJg") { youtube(user_params: true) }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>', result
+  end
+
+  def test_transform_with_start_timecode
+    result = auto_html("https://www.youtube.com/watch?v=t7NdBIA4zJg?t=1m30s") { youtube(user_params: true) }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg?start=90" frameborder="0" allowfullscreen></iframe></div>', result
+  end
+
   def test_transform_https
     result = auto_html("https://www.youtube.com/watch?v=t7NdBIA4zJg") { youtube }
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>', result
@@ -50,6 +60,16 @@ class YouTubeTest < Test::Unit::TestCase
   def test_short_with_params
     result = auto_html("http://youtu.be/t7NdBIA4zJg?t=1s&hd=1") { youtube }
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>', result
+  end
+
+  def test_short_with_start_time
+    result = auto_html("http://youtu.be/t7NdBIA4zJg?start=200sdfsdg&end=300s&hd=1") { youtube(user_params: true) }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg?start=200&end=300" frameborder="0" allowfullscreen></iframe></div>', result
+  end
+
+  def test_short_with_start_timecode
+    result = auto_html("http://youtu.be/t7NdBIA4zJg?t=1m30s&hd=1") { youtube(user_params: true) }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg?start=90" frameborder="0" allowfullscreen></iframe></div>', result
   end
 
   def test_transform_without_protocol

--- a/test/unit/filters/youtube_test.rb
+++ b/test/unit/filters/youtube_test.rb
@@ -76,4 +76,9 @@ class YouTubeTest < Test::Unit::TestCase
     result = auto_html("www.youtube.com/watch?v=t7NdBIA4zJg") { youtube }
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>', result
   end
+
+  def test_multiple_questionable_urls_in_one_string
+    result = auto_html("http://www.youtube.com/watch?v=bjN8_S4xVc4&amp;feature=share&amp;list=TL5YfrkNQnNVE http://www.youtube.com/watch?v=79maSdfxQCU&amp;list=TL3GbaFhZ6ji4") { youtube(user_params: true) }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/bjN8_S4xVc4" frameborder="0" allowfullscreen></iframe></div> <div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/79maSdfxQCU" frameborder="0" allowfullscreen></iframe></div>', result
+  end
 end

--- a/test/unit/filters/youtube_test.rb
+++ b/test/unit/filters/youtube_test.rb
@@ -17,12 +17,12 @@ class YouTubeTest < Test::Unit::TestCase
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/BwNrmYRiX_o" frameborder="0" allowfullscreen></iframe></div>', result
   end
 
-  def test_transform3
+  def test_transform4
     result = auto_html('foo http://www.youtube.com/watch?v=fT1ahr81HLw bar') { youtube }
     assert_equal 'foo <div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/fT1ahr81HLw" frameborder="0" allowfullscreen></iframe></div> bar', result
   end
 
-  def test_transform4
+  def test_transform5
     result = auto_html('foo http://www.youtube.com/watch?v=fT1ahr81HLw<br>bar') { youtube }
     assert_equal 'foo <div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/fT1ahr81HLw" frameborder="0" allowfullscreen></iframe></div><br>bar', result
   end


### PR DESCRIPTION
Set user_params to true to enable handling of URLs like:

    http://youtube.com/watch?v=1234567890&t=5m30s
    http://youtube.com/watch?v=1234567890&start=90
    http://youtube.com/watch?v=1234567890&start=90&end=120