### PR TITLE
update youtube filter to handle m subdomain

### DIFF
--- a/lib/auto_html/filters/youtube.rb
+++ b/lib/auto_html/filters/youtube.rb
@@ -1,5 +1,5 @@
 AutoHtml.add_filter(:youtube).with(:width => 420, :height => 315, :frameborder => 0, :wmode => nil, :autoplay => false, :hide_related => false) do |text, options|
-  regex = /(https?:\/\/)?(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
+  regex = /(https?:\/\/)?(m.|www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
   text.gsub(regex) do
     youtube_id = $4
     width = options[:width]

--- a/lib/auto_html/filters/youtube.rb
+++ b/lib/auto_html/filters/youtube.rb
@@ -1,4 +1,4 @@
-AutoHtml.add_filter(:youtube).with(:width => 420, :height => 315, :frameborder => 0, :wmode => nil, :autoplay => false, :hide_related => false) do |text, options|
+AutoHtml.add_filter(:youtube).with(:width => 420, :height => 315, :wmode => nil, :autoplay => false, :hide_related => false) do |text, options|
   regex = /(https?:\/\/)?(m.|www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
   text.gsub(regex) do
     youtube_id = $4
@@ -14,6 +14,6 @@ AutoHtml.add_filter(:youtube).with(:width => 420, :height => 315, :frameborder =
     params << "autoplay=1" if autoplay
     params << "rel=0" if hide_related
     src += "?#{params.join '&'}" unless params.empty?
-    %{<div class="video youtube"><iframe width="#{width}" height="#{height}" src="#{src}" frameborder="#{frameborder}" allowfullscreen></iframe></div>}
+    %{<div class="video youtube embed-responsive embed-responsive-4by3"><iframe width="#{width}" height="#{height}" src="#{src}" allowfullscreen></iframe></div>}
   end
 end

--- a/test/unit/filters/youtube_test.rb
+++ b/test/unit/filters/youtube_test.rb
@@ -56,4 +56,14 @@ class YouTubeTest < Test::Unit::TestCase
     result = auto_html("www.youtube.com/watch?v=t7NdBIA4zJg") { youtube }
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>', result
   end
+
+  def test_transform_with_m_subdomain
+    result = auto_html("http://m.youtube.com/watch?v=t7NdBIA4zJg") { youtube }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>', result
+  end
+
+  def test_transform_with_m_subdomain_and_short_url
+    result = auto_html("http://m.youtu.be/BwNrmYRiX_o") { youtube }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/BwNrmYRiX_o" frameborder="0" allowfullscreen></iframe></div>', result
+  end
 end


### PR DESCRIPTION
Before: youtube filter extracts 'm.' from m.youtube.com and renders 'm.' as visible text.

After: m.youtube.com is fully parsed and 'm.' is not extracted.