### PR TITLE
Add support for more vimeo url formats

### DIFF
--- a/lib/auto_html/filters/vimeo.rb
+++ b/lib/auto_html/filters/vimeo.rb
@@ -1,5 +1,5 @@
 AutoHtml.add_filter(:vimeo).with(:width => 440, :height => 248, :show_title => false, :show_byline => false, :show_portrait => false) do |text, options|
-  text.gsub(/(?:https?:)?\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/) do
+  text.gsub(/(?:https?:)?\/\/(?:(?:player.vimeo.com\/video)|(?:(www.)?vimeo\.com))\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/) do
     vimeo_id = $2
     width  = options[:width]
     height = options[:height]

--- a/lib/auto_html/filters/vimeo.rb
+++ b/lib/auto_html/filters/vimeo.rb
@@ -1,10 +1,10 @@
 AutoHtml.add_filter(:vimeo).with(:width => 440, :height => 248, :show_title => false, :show_byline => false, :show_portrait => false) do |text, options|
-  text.gsub(/https?:\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/) do
+  text.gsub(/(?:https?:)?\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/) do
     vimeo_id = $2
     width  = options[:width]
     height = options[:height]
     show_title      = "title=0"    unless options[:show_title]
-    show_byline     = "byline=0"   unless options[:show_byline]  
+    show_byline     = "byline=0"   unless options[:show_byline]
     show_portrait   = "portrait=0" unless options[:show_portrait]
     frameborder     = options[:frameborder] || 0
     query_string_variables = [show_title, show_byline, show_portrait].compact.join("&")

--- a/test/unit/filters/vimeo_test.rb
+++ b/test/unit/filters/vimeo_test.rb
@@ -12,6 +12,11 @@ class VimeoTest < Test::Unit::TestCase
     assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
   end
 
+  def test_transform_url_protocol_agnostic
+    result = auto_html('//vimeo.com/3300155') { vimeo }
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
+  end
+
   def test_transform_url_with_params
     result = auto_html('http://vimeo.com/3300155?pg=embed&sec=') { vimeo }
     assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result

--- a/test/unit/filters/vimeo_test.rb
+++ b/test/unit/filters/vimeo_test.rb
@@ -12,6 +12,11 @@ class VimeoTest < Test::Unit::TestCase
     assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
   end
 
+  def test_transform_url_with_player
+    result = auto_html('http://player.vimeo.com/video/3300155') { vimeo }
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
+  end
+
   def test_transform_url_protocol_agnostic
     result = auto_html('//vimeo.com/3300155') { vimeo }
     assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result


### PR DESCRIPTION
- Player url e.g. `http://player.video.com/video/95342512` (The format used in their embed code)
- Add support for protocol agnostic url's e.g. `//vimeo.com/95342512`