### PR TITLE
Fix auto_html does not render link and image separated by HTML tag correctly

### DIFF
--- a/lib/auto_html/filters/image.rb
+++ b/lib/auto_html/filters/image.rb
@@ -10,7 +10,7 @@ AutoHtml.add_filter(:image).with({:alt => ''}) do |text, options|
   r = Redcarpet::Markdown.new(NoParagraphRenderer)
   alt = options[:alt]
   options[:proxy] ||= ""
-  text.gsub(/(?<!src=")https?:\/\/.+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
+  text.gsub(/(?<!src=")https?:\/\/[^<>]+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
     r.render("![#{alt}](#{options[:proxy]}#{match})")
   end
 end

--- a/lib/auto_html/filters/image.rb
+++ b/lib/auto_html/filters/image.rb
@@ -10,7 +10,7 @@ AutoHtml.add_filter(:image).with({:alt => ''}) do |text, options|
   r = Redcarpet::Markdown.new(NoParagraphRenderer)
   alt = options[:alt]
   options[:proxy] ||= ""
-  text.gsub(/(?<!src=")https?:\/\/[^<>]+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
+  text.gsub(/(?<!src=")https?:\/\/[^<>\s]+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
     r.render("![#{alt}](#{options[:proxy]}#{match})")
   end
 end

--- a/test/unit/auto_html_test.rb
+++ b/test/unit/auto_html_test.rb
@@ -23,6 +23,11 @@ class AutoHtmlTest < Test::Unit::TestCase
     result = auto_html("Check the logo: http://rors.org/images/rails.png. Visit: http://rubyonrails.org") { simple_format; image(:alt => nil); link }
     assert_equal '<p>Check the logo: <img src="http://rors.org/images/rails.png" alt=""/>. Visit: <a href="http://rubyonrails.org" >http://rubyonrails.org</a></p>', result
   end
+
+  def test_should_accept_html_with_link_and_image
+    result = auto_html("Website: http://www.google.com<br/>http://rors.org/images/rails.png") { image(:alt => nil); link }
+    assert_equal 'Website: <a href="http://www.google.com" >http://www.google.com</a><br/><img src="http://rors.org/images/rails.png" alt=""/>', result
+  end
   
   def test_should_return_blank_if_input_is_blank
     result = auto_html("") { simple_format; image(:alt => nil); link }


### PR DESCRIPTION
Currently, if you have an HTML text with link and image separated by a div or a br, the resulting text is broken.

i.e.
```Website: http://www.google.com<br/>http://rors.org/images/rails.png```

compiles to

```Website: <img src="http://www.google.com%3Cbr/%3Ehttp://rors.org/images/rails.png" alt=""/>```

instead of

```Website: <a href="http://www.google.com">http://www.google.com</a><br/><img src="http://rors.org/images/rails.png" alt="">```

This commit solve this issue.