### PR TITLE
Convert '&' into '&amp;'

### DIFF
--- a/lib/auto_html/filters/vimeo.rb
+++ b/lib/auto_html/filters/vimeo.rb
@@ -4,10 +4,10 @@ AutoHtml.add_filter(:vimeo).with(:width => 440, :height => 248, :show_title => f
     width  = options[:width]
     height = options[:height]
     show_title      = "title=0"    unless options[:show_title]
-    show_byline     = "byline=0"   unless options[:show_byline]  
+    show_byline     = "byline=0"   unless options[:show_byline]
     show_portrait   = "portrait=0" unless options[:show_portrait]
     frameborder     = options[:frameborder] || 0
-    query_string_variables = [show_title, show_byline, show_portrait].compact.join("&")
+    query_string_variables = [show_title, show_byline, show_portrait].compact.join("&amp;")
     query_string    = "?" + query_string_variables unless query_string_variables.empty?
 
     %{<iframe src="//player.vimeo.com/video/#{vimeo_id}#{query_string}" width="#{width}" height="#{height}" frameborder="#{frameborder}"></iframe>}

--- a/test/unit/filters/vimeo_test.rb
+++ b/test/unit/filters/vimeo_test.rb
@@ -4,47 +4,47 @@ class VimeoTest < Test::Unit::TestCase
 
   def test_transform_url_with_www
     result = auto_html('http://www.vimeo.com/3300155') { vimeo }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&amp;byline=0&amp;portrait=0" width="440" height="248" frameborder="0"></iframe>', result
   end
 
   def test_transform_url_without_www
     result = auto_html('http://vimeo.com/3300155') { vimeo }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&amp;byline=0&amp;portrait=0" width="440" height="248" frameborder="0"></iframe>', result
   end
 
   def test_transform_url_with_params
     result = auto_html('http://vimeo.com/3300155?pg=embed&sec=') { vimeo }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&amp;byline=0&amp;portrait=0" width="440" height="248" frameborder="0"></iframe>', result
   end
 
   def test_transform_url_with_anchor
     result = auto_html('http://vimeo.com/3300155#skirt') { vimeo }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&amp;byline=0&amp;portrait=0" width="440" height="248" frameborder="0"></iframe>', result
   end
 
   def test_transform_with_options
     result = auto_html("http://www.vimeo.com/3300155") { vimeo(:width => 300, :height => 250) }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="300" height="250" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&amp;byline=0&amp;portrait=0" width="300" height="250" frameborder="0"></iframe>', result
   end
 
   def test_transform_with_title
     result = auto_html("http://www.vimeo.com/3300155") { vimeo(:width => 300, :height => 250, :show_title => true) }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?byline=0&portrait=0" width="300" height="250" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?byline=0&amp;portrait=0" width="300" height="250" frameborder="0"></iframe>', result
   end
 
   def test_transform_with_byline
     result = auto_html("http://www.vimeo.com/3300155") { vimeo(:width => 300, :height => 250, :show_byline => true) }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&portrait=0" width="300" height="250" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&amp;portrait=0" width="300" height="250" frameborder="0"></iframe>', result
   end
 
   def test_transform_with_portrait
     result = auto_html("http://www.vimeo.com/3300155") { vimeo(:width => 300, :height => 250, :show_portrait => true) }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0" width="300" height="250" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&amp;byline=0" width="300" height="250" frameborder="0"></iframe>', result
   end
-  
+
   def test_transform_url_with_https
     result = auto_html('https://vimeo.com/3300155') { vimeo }
-    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>', result
+    assert_equal '<iframe src="//player.vimeo.com/video/3300155?title=0&amp;byline=0&amp;portrait=0" width="440" height="248" frameborder="0"></iframe>', result
   end
 
 end


### PR DESCRIPTION
The vimeo filter is injecting ampersands into the markup instead of &amp;