### PR TITLE
Filters: handle alphanumeric gist ids

### DIFF
--- a/lib/auto_html/filters/gist.rb
+++ b/lib/auto_html/filters/gist.rb
@@ -1,8 +1,13 @@
 AutoHtml.add_filter(:gist).with({}) do |text, options|
-  # E.g. https://gist.github.com/1710276
-  regex = %r{https?://gist\.github\.com/(\w+/)?(\d+)}
+
+  # E.g.
+  #
+  #   Gist id: https://gist.github.com/1710276
+  #   Username plus id: https://gist.github.com/toctan/c9d3677da5aa021b5c03
+  #
+  regex = %r{https?:\/\/gist\.github\.com\/(\w+\/)?(\w+)}
   text.gsub(regex) do
     gist_id = $2
-    %{<script type="text/javascript" src="https://gist.github.com/#{gist_id}.js"></script>}
+    %{<script src="https://gist.github.com/#{gist_id}.js"></script>}
   end
 end

--- a/test/unit/filters/gist_test.rb
+++ b/test/unit/filters/gist_test.rb
@@ -4,12 +4,12 @@ class GistTest < Minitest::Test
 
   def test_transform
     result = auto_html('https://gist.github.com/1710276') { gist }
-    assert_equal '<script type="text/javascript" src="https://gist.github.com/1710276.js"></script>', result
+    assert_equal '<script src="https://gist.github.com/1710276.js"></script>', result
   end
 
   def test_transform_with_username
-    result = auto_html('https://gist.github.com/toctan/6547840') { gist }
-    assert_equal '<script type="text/javascript" src="https://gist.github.com/6547840.js"></script>', result
+    result = auto_html('https://gist.github.com/toctan/c9d3677da5aa021b5c03') { gist }
+    assert_equal '<script src="https://gist.github.com/c9d3677da5aa021b5c03.js"></script>', result
   end
 
 end


### PR DESCRIPTION
Handle alphanumeric gist ids. 
E.G: https://gist.github.com/PabloVallejo/2573776b1bd83af95504

> Current regexp

![online_regex_tester_and_debugger__javascript__python__php__and_pcre](https://cloud.githubusercontent.com/assets/1751074/7645193/d3d39d54-fa76-11e4-83ac-e28277d7d360.jpg)

> New regexp

![online_regex_tester_and_debugger__javascript__python__php__and_pcre](https://cloud.githubusercontent.com/assets/1751074/7645200/e2dbcb14-fa76-11e4-90ad-28320e4cbb3f.jpg)
