### PR TITLE
Added support to Youtube's start URL param.

### DIFF
--- a/lib/auto_html/filters/youtube.rb
+++ b/lib/auto_html/filters/youtube.rb
@@ -1,18 +1,23 @@
 AutoHtml.add_filter(:youtube).with(:width => 420, :height => 315, :frameborder => 0, :wmode => nil, :autoplay => false, :hide_related => false) do |text, options|
   regex = /(https?:\/\/)?(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
-  text.gsub(regex) do
-    youtube_id = $4
-    width = options[:width]
-    height = options[:height]
-    frameborder = options[:frameborder]
-		wmode = options[:wmode]
-    autoplay = options[:autoplay]
+  text.gsub(regex) do |url|
+    youtube_id   = $4
+    width        = options[:width]
+    height       = options[:height]
+    frameborder  = options[:frameborder]
+    wmode        = options[:wmode]
+    autoplay     = options[:autoplay]
     hide_related = options[:hide_related]
-		src = "//www.youtube.com/embed/#{youtube_id}"
+    start        = url.match(/&start=([0-9]+)/).try(:[], 1)
+
+    src = "//www.youtube.com/embed/#{youtube_id}"
+
     params = []
-		params << "wmode=#{wmode}" if wmode
-    params << "autoplay=1" if autoplay
-    params << "rel=0" if hide_related
+    params << "wmode=#{wmode}" if wmode
+    params << "autoplay=1"     if autoplay
+    params << "rel=0"          if hide_related
+    params << "start=#{start}" if start
+
     src += "?#{params.join '&'}" unless params.empty?
     %{<div class="video youtube"><iframe width="#{width}" height="#{height}" src="#{src}" frameborder="#{frameborder}" allowfullscreen></iframe></div>}
   end

--- a/test/unit/filters/youtube_test.rb
+++ b/test/unit/filters/youtube_test.rb
@@ -56,4 +56,9 @@ class YouTubeTest < Minitest::Test
     result = auto_html("www.youtube.com/watch?v=t7NdBIA4zJg") { youtube }
     assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen></iframe></div>', result
   end
+
+  def test_transform_with_start_param
+    result = auto_html("www.youtube.com/watch?v=t7NdBIA4zJg&start=30") { youtube }
+    assert_equal '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg?start=30" frameborder="0" allowfullscreen></iframe></div>', result
+  end
 end


### PR DESCRIPTION
Tiny useful feature.

By the way, is this test alright?
https://github.com/dejan/auto_html/blob/master/test/unit/filters/youtube_test.rb#L50

IMO it's not. Shouldn't we convert those shortened params? (e.g. t => start)
I understand that would be a hassle though.

PS: Thanks @dejan and contributors of auto_html! :)