### PR TITLE
fix :sanitize for Rails >= 4.2

### DIFF
--- a/lib/auto_html/filters/sanitize.rb
+++ b/lib/auto_html/filters/sanitize.rb
@@ -1,5 +1,12 @@
 AutoHtml.add_filter(:sanitize).with({}) do |text, options|
   require 'action_controller'
   require 'cgi'
-  HTML::WhiteListSanitizer.new.sanitize(text, options)
+
+  sanitizer_class = if defined?(HTML::WhiteListSanitizer)
+      HTML::WhiteListSanitizer
+    else
+      Rails::Html::WhiteListSanitizer
+    end
+
+  sanitizer_class.new.sanitize(text, options)
 end


### PR DESCRIPTION
Fixes #159 

Rails 4.2 removed deprecated `HTML::WhiteListSanitizer` in favour of `Rails::Html::WhiteListSanitizer`. You can maintain the old behaviour by using `rails-deprecated_sanitizer` gem, but I think that it is more consistent to just check whether the old sanitizer is available, and fallback to the new otherwise. 

You can check how this solves the issue by: 

    #> RAILS_VERSION=4.2 bundle install
    #> RAILS_VERSION=4.2 bundle exec rake test

Regards!