### PR TITLE
Fix for nofollow on link filter

### DIFF
--- a/lib/auto_html/link.rb
+++ b/lib/auto_html/link.rb
@@ -11,13 +11,13 @@ module AutoHtml
     end
 
     def call(text)
-      Rinku.auto_link(text, :all, target_attr)
+      Rinku.auto_link(text, :all, attributes)
     end
 
     private
 
     def attributes
-      [target_attr, rel_attr].compact.join(' ')
+      [target_attr, rel_attr].compact.join(' ') unless [target_attr, rel_attr].compact.empty?
     end
 
     def rel_attr

--- a/spec/auto_html/link_spec.rb
+++ b/spec/auto_html/link_spec.rb
@@ -31,9 +31,21 @@ RSpec.describe AutoHtml::Link do
     expect(result).to eq '<a href="http://www.google.com/#q=nikola+tesla&ct=tesla09&oi=ddle&fp=Xmf0jJ9P_V0">http://www.google.com/#q=nikola+tesla&ct=tesla09&oi=ddle&fp=Xmf0jJ9P_V0</a>'
   end
 
-  it 'transforms with options' do
+  it 'transforms with target options' do
     filter = described_class.new(target: '_blank')
     result = filter.call('http://rors.org')
     expect(result).to eq '<a href="http://rors.org" target="_blank">http://rors.org</a>'
+  end
+
+  it 'transforms with rel options' do
+    filter = described_class.new(rel: 'nofollow')
+    result = filter.call('http://rors.org')
+    expect(result).to eq '<a href="http://rors.org" rel="nofollow">http://rors.org</a>'
+  end
+
+  it 'transforms with target and rel options' do
+    filter = described_class.new(target: '_blank', rel: 'nofollow')
+    result = filter.call('http://rors.org')
+    expect(result).to eq '<a href="http://rors.org" target="_blank" rel="nofollow">http://rors.org</a>'
   end
 end


### PR DESCRIPTION
Hi, 

I updated link filter to use this.

```ruby
AutoHtml::Link.new(rel: 'nofollow') 
```
Can you please merge this?