### PR TITLE
fix link rel attribute

### DIFF
--- a/lib/auto_html/link.rb
+++ b/lib/auto_html/link.rb
@@ -13,7 +13,7 @@ module AutoHtml
     end
 
     def call(text)
-      Rinku.auto_link(text, :all, target_attr)
+      Rinku.auto_link(text, :all, attributes)
     end
 
     private


### PR DESCRIPTION
Seems like we want to reference `attributes` so both `target` and `rel` are accounted for.