### PR TITLE
Merge tag_helper

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,3 +1,0 @@
-workflow "New workflow" {
-  on = "push"
-}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, '3.0', head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby: [2.5, 2.6, 2.7, '3.0', head, truffleruby, truffleruby-head]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,16 @@ name: Ruby
 on: [push]
 
 jobs:
-  build:
-
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.5, 2.6, 2.7, '3.0', head, jruby, jruby-head, truffleruby, truffleruby-head]
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
-    - name: Build and test with Rake
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-Gemfile.lock
 *.gem
 TODO

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   NewCops: enable
   TargetRubyVersion: 2.5
+  SuggestExtensions: false
 
 Metrics/MethodLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  NewCops: enable
+  TargetRubyVersion: 2.5
 
 Metrics/MethodLength:
   Enabled: false
@@ -8,7 +9,4 @@ Metrics/LineLength:
   Enabled: false
 
 Metrics/BlockLength:
-  Enabled: false
-
-Gemspec/RequiredRubyVersion:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,64 @@
+PATH
+  remote: .
+  specs:
+    auto_html (2.0.0)
+      gemoji (~> 2.1)
+      redcarpet (~> 3.5)
+      rinku (~> 2.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    ast (2.4.2)
+    diff-lcs (1.4.4)
+    gemoji (2.1.0)
+    parallel (1.20.1)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    rake (13.0.6)
+    redcarpet (3.5.1)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rinku (2.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    rubocop (0.89.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.3.0, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.8.0)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (1.7.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  auto_html!
+  rake (>= 12.3.3)
+  rspec (~> 3.3)
+  rspec_junit_formatter (~> 0.2)
+  rubocop (~> 0.89.1)
+
+BUNDLED WITH
+   2.2.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     unicode-display_width (1.7.0)
 
 PLATFORMS
+  universal-java-11
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GEM
     ast (2.4.2)
     diff-lcs (1.4.4)
     gemoji (2.1.0)
-    parallel (1.20.1)
-    parser (3.0.2.0)
+    parallel (1.21.0)
+    parser (3.0.3.1)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.6)
@@ -36,19 +36,19 @@ GEM
     rspec-support (3.10.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.89.1)
+    rubocop (1.23.0)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.3.0, < 1.0)
+      rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.8.0)
-      parser (>= 2.7.1.5)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.13.0)
+      parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   universal-java-11
@@ -56,10 +56,10 @@ PLATFORMS
 
 DEPENDENCIES
   auto_html!
-  rake (>= 12.3.3)
+  rake (~> 13.0.6)
   rspec (~> 3.3)
   rspec_junit_formatter (~> 0.2)
-  rubocop (~> 0.89.1)
+  rubocop (~> 1.23)
 
 BUNDLED WITH
    2.2.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,6 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
-  universal-java-11
   x86_64-linux
 
 DEPENDENCIES

--- a/auto_html.gemspec
+++ b/auto_html.gemspec
@@ -18,11 +18,14 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5.0'
 
-  gem.add_development_dependency 'rake', '>= 12.3.3'
+  gem.add_development_dependency 'rake', '~> 13.0.6'
   gem.add_development_dependency 'rspec', '~> 3.3'
   gem.add_development_dependency 'rspec_junit_formatter', '~> 0.2'
-  gem.add_development_dependency 'rubocop', '~> 0.89.1'
+  gem.add_development_dependency 'rubocop', '~> 1.23'
 
   gem.files = Dir['Rakefile', '{bin,lib,man,test,spec}/**/*',
                   'README*', 'LICENSE'] & `git ls-files -z`.split("\0")
+  gem.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 end

--- a/auto_html.gemspec
+++ b/auto_html.gemspec
@@ -15,9 +15,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'gemoji', '~> 2.1'
   gem.add_dependency 'redcarpet', '~> 3.5'
   gem.add_dependency 'rinku', '~> 2.0'
-  gem.add_dependency 'tag_helper', '~> 0.5'
 
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.5.0'
 
   gem.add_development_dependency 'rake', '>= 12.3.3'
   gem.add_development_dependency 'rspec', '~> 3.3'

--- a/lib/auto_html.rb
+++ b/lib/auto_html.rb
@@ -3,7 +3,7 @@
 # AutoHtml is a collection of filters that transform plain text into HTML code.
 module AutoHtml
   autoload :Pipeline,     'auto_html/pipeline'
-
+  autoload :TagHelper,    'auto_html/tag_helper'
   autoload :Emoji,        'auto_html/emoji'
   autoload :HtmlEscape,   'auto_html/html_escape'
   autoload :Image,        'auto_html/image'

--- a/lib/auto_html/emoji.rb
+++ b/lib/auto_html/emoji.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'tag_helper'
 require 'gemoji'
 
 module AutoHtml

--- a/lib/auto_html/image.rb
+++ b/lib/auto_html/image.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'tag_helper'
-
 module AutoHtml
   # Image filter
   class Image
@@ -19,7 +17,7 @@ module AutoHtml
     private
 
     def image_pattern
-      %r{(?<!src=")https?:\/\/.+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?}i
+      %r{(?<!src=")https?://.+?\.(jpg|jpeg|bmp|gif|png)(\?\S+)?}i
     end
   end
 end

--- a/lib/auto_html/simple_format.rb
+++ b/lib/auto_html/simple_format.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'tag_helper'
-
 module AutoHtml
   # SimpleFormat filter
   class SimpleFormat

--- a/lib/auto_html/tag_helper.rb
+++ b/lib/auto_html/tag_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module AutoHtml
+  # XHTML tags builder
+  module TagHelper
+    def tag(tag_name, attrs = {})
+      if block_given?
+        content_tag(tag_name, yield, attrs)
+      else
+        unary_tag(tag_name, attrs)
+      end
+    end
+
+    private
+
+    def unary_tag(tag_name, attrs = {})
+      "<#{tag_and_attributes(tag_name, tag_attributes(attrs))} />"
+    end
+
+    def content_tag(tag_name, value, attrs = {})
+      start_tag = "<#{tag_and_attributes(tag_name, tag_attributes(attrs))}>"
+      end_tag   = "</#{tag_name}>"
+      [start_tag, value, end_tag].join
+    end
+
+    def tag_and_attributes(tag_name, attributes)
+      attributes.empty? ? tag_name : "#{tag_name} #{attributes}"
+    end
+
+    def tag_attributes(hash)
+      hash.compact
+          .to_a
+          .map { |k, v| %(#{k}="#{v}") }.join(' ')
+    end
+
+    extend self
+  end
+end

--- a/spec/auto_html/tag_helper_spec.rb
+++ b/spec/auto_html/tag_helper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe AutoHtml::TagHelper do
+  it 'generates tag with attributes' do
+    result = subject.tag(:img, src: '1.png', alt: 'number one!')
+    expect(result).to eq '<img src="1.png" alt="number one!" />'
+  end
+
+  it 'generates tag without attributes' do
+    result = subject.tag(:br)
+    expect(result).to eq '<br />'
+  end
+
+  it 'generates content tags' do
+    result = subject.tag(:label, for: 'name') { 'Name' }
+    expect(result).to eq '<label for="name">Name</label>'
+  end
+
+  it 'generates content tags without attributes' do
+    result = subject.tag(:label) { 'Username' }
+    expect(result).to eq '<label>Username</label>'
+  end
+
+  it 'generates nested tags' do
+    result = subject.tag(:form) { subject.tag(:input, type: 'text') }
+    expect(result).to eq '<form><input type="text" /></form>'
+  end
+end


### PR DESCRIPTION
tag_helper gem repo is now archived, so the code can continue to live here.

Other minor things are done as well: 
- upgrade rubocop and rake
- introduce ruby version test matrix
- bring Gemfile.lock to repo