### PR TITLE
Add rexml dependency (moved to gem in Ruby 3.0.0)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     auto_html (2.1.0)
       gemoji (~> 4.0.0.rc2)
       redcarpet (~> 3.5)
+      rexml (~> 3.2.5)
       rinku (~> 2.0)
 
 GEM
@@ -51,6 +52,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/auto_html.gemspec
+++ b/auto_html.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'gemoji', '~> 4.0.0.rc2'
   gem.add_dependency 'redcarpet', '~> 3.5'
   gem.add_dependency 'rinku', '~> 2.0'
+  gem.add_dependency 'rexml', '~> 3.2.5'
 
   gem.required_ruby_version = '>= 2.5.0'
 


### PR DESCRIPTION
`rexml` was moved to a gem in Ruby 3.0.0.

https://www.ruby-lang.org/en/news/2020/09/25/ruby-3-0-0-preview1-released/