### PR TITLE
Added short_domains argument to initialize.

### DIFF
--- a/lib/auto_html/link.rb
+++ b/lib/auto_html/link.rb
@@ -7,13 +7,14 @@ require 'rexml/document'
 module AutoHtml
   # Link filter
   class Link
-    def initialize(target: nil, rel: nil)
+    def initialize(target: nil, rel: nil, short_domains: false)
       @target = target
       @rel = rel
+      @short_domains = short_domains
     end
 
     def call(text)
-      Rinku.auto_link(text, :all, attributes)
+      Rinku.auto_link(text, :all, attributes, nil, flags)
     end
 
     private
@@ -28,6 +29,10 @@ module AutoHtml
 
     def target_attr
       %(target="#{@target}") if @target
+    end
+
+    def flags
+      @short_domains ? Rinku::AUTOLINK_SHORT_DOMAINS : 0
     end
   end
 end

--- a/spec/auto_html/link_spec.rb
+++ b/spec/auto_html/link_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe AutoHtml::Link do
     expect(result).to eq '<a href="http://www.google.com/#q=nikola+tesla&ct=tesla09&oi=ddle&fp=Xmf0jJ9P_V0">http://www.google.com/#q=nikola+tesla&ct=tesla09&oi=ddle&fp=Xmf0jJ9P_V0</a>'
   end
 
+  it 'not transforms short domain URL' do
+    result = subject.call('http://localhost:3000')
+    expect(result).to eq 'http://localhost:3000'
+  end
+
   it 'transforms with target options' do
     filter = described_class.new(target: '_blank')
     result = filter.call('http://rors.org')
@@ -43,6 +48,12 @@ RSpec.describe AutoHtml::Link do
     filter = described_class.new(rel: 'nofollow')
     result = filter.call('http://rors.org')
     expect(result).to eq '<a href="http://rors.org" rel="nofollow">http://rors.org</a>'
+  end
+
+  it 'transforms with short_domains options' do
+    filter = described_class.new(short_domains: true)
+    result = filter.call('http://localhost:3000')
+    expect(result).to eq '<a href="http://localhost:3000">http://localhost:3000</a>'
   end
 
   it 'transforms with target and rel options' do


### PR DESCRIPTION
close: #186

Added `short_domains` argument to initialize method to accept `Boolean`.
This is `false` by default, and if you set it to `true`, `Rinku::AUTOLINK_SHORT_DOMAINS` will be set to the flags argument of `Rinku.auto_link`.
This allows you to autolink short domains.

```rb
AutoHtml::Link.new(short_domains: true).call('http://localhost:3000')
#=> "<a href=\"http://localhost:3000\">http://localhost:3000</a>"
```

The reason for using `Boolean` is to isolate the behavior for each environment.

```rb
AutoHtml::Link.new(short_domains: !Rails.env.production?)
```


There is no change to the default behavior, so existing projects that use this gem will not be affected.

```rb
AutoHtml::Link.new.call('http://localhost:3000')
#=> "http://localhost:3000"
```