### PR TITLE
Remove references to the hijacked demo domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoHtml
 
-AutoHtml is a collection of filters that transforms plain text into HTML code. See [live demo](https://autohtml.rors.org).
+AutoHtml is a collection of filters that transforms plain text into HTML code.
 
 ## Installation
 
@@ -33,8 +33,8 @@ AutoHtml uses concepts found in "Pipes and Filters" processing design pattern:
 
 ```ruby
 link_filter = AutoHtml::Link.new(target: '_blank')
-link_filter.call('Checkout out my blog: http://rors.org')
-# => 'Checkout out my blog: <a target="blank" href="http://rors.org">http://rors.org</a>'
+link_filter.call('Checkout out my blog: https://www.rubyonrails.org')
+# => 'Checkout out my blog: <a target="blank" href="https://www.rubyonrails.org">https://www.rubyonrails.org</a>'
 
 emoji_filter = AutoHtml::Emoji.new
 emoji_filter.call(':point_left: yo!')
@@ -42,14 +42,14 @@ emoji_filter.call(':point_left: yo!')
 
 # Use Pipeline to combine filters
 base_format = AutoHtml::Pipeline.new(link_filter, emoji_filter)
-base_format.call('Checkout out my blog: http://rors.org :point_left: yo!')
-# => 'Checkout out my blog: <a href="http://rors.org">http://rors.org</a> <img src="/images/emoji/unicode/1f448.png" class="emoji" title=":point_left:" alt=":point_left:" height="20" witdh="20" align="absmiddle" /> yo!'
+base_format.call('Checkout out my blog: https://www.rubyonrails.org :point_left: yo!')
+# => 'Checkout out my blog: <a href="https://www.rubyonrails.org">https://www.rubyonrails.org</a> <img src="/images/emoji/unicode/1f448.png" class="emoji" title=":point_left:" alt=":point_left:" height="20" witdh="20" align="absmiddle" /> yo!'
 
 # A pipeline can be reused in another pipeline. Note that the order of filters is important - ie you want
 # `Image` before `Link` filter so that URL of the image gets transformed to `img` tag and not `a` tag.
 comment_format = AutoHtml::Pipeline.new(AutoHtml::Markdown.new, AutoHtml::Image.new, base_format)
-comment_format.call("Hello!\n\n Checkout out my blog: http://rors.org :point_left: yo! \n\n http://gifs.joelglovier.com/boom/booyah.gif")
-# => "<p>Hello!</p>\n\n<p>Checkout out my blog: <a href="<img src="http://rors.org" target="_blank">http://rors.org</a> <img src="/images/emoji/unicode/1f448.png" />" class="emoji" title=":point_left:" alt=":point_left:" height="20" witdh="20" align="absmiddle" /> yo! </p>\n\n<p><a href="<img src="http://gifs.joelglovier.com/boom/booyah.gif" />" target="_blank"><img src="http://gifs.joelglovier.com/boom/booyah.gif" /></a></p>\n"
+comment_format.call("Hello!\n\n Checkout out my blog: https://www.rubyonrails.org :point_left: yo! \n\n http://gifs.joelglovier.com/boom/booyah.gif")
+# => "<p>Hello!</p>\n\n<p>Checkout out my blog: <a href="<img src="https://www.rubyonrails.org" target="_blank">https://www.rubyonrails.org</a> <img src="/images/emoji/unicode/1f448.png" />" class="emoji" title=":point_left:" alt=":point_left:" height="20" witdh="20" align="absmiddle" /> yo! </p>\n\n<p><a href="<img src="http://gifs.joelglovier.com/boom/booyah.gif" />" target="_blank"><img src="http://gifs.joelglovier.com/boom/booyah.gif" /></a></p>\n"
 ```
 
 ## Bundled filters


### PR DESCRIPTION
Hi @dejan,

Thanks for your work on this project! It seems your domain is hijacked. As the domain wasn't working anyway, I've updated all references to the official Ruby On Rails website. 

I'd recommend removing the URL on the GitHub repository as well.


<img width="473" alt="Screenshot 2022-10-04 at 11 10 37" src="https://user-images.githubusercontent.com/1470863/193781327-dc8ae92b-a4d5-4038-ab61-2ecf7a85a1fe.png">
